### PR TITLE
Multi-Repo Support

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -64,7 +64,7 @@ const onChangePull = async (pull: PullRequest) => {
     console.log(`No channel for PR${pull.number}`);
     pullChannel = await createPullChannel(slackApp, pull);
 
-    await addInitialComment(githubApp, pull.number, pullChannel);
+    await addInitialComment(githubApp, pull, pullChannel);
   }
 
   if (!pullChannel.is_archived) {

--- a/app.ts
+++ b/app.ts
@@ -57,7 +57,7 @@ const onChangePull = async (pull: PullRequest) => {
   const channels = await getSlackChannels(slackApp);
 
   let pullChannel = channels.find(
-    (channel) => channel.name === `pr-${pull.number}-${process.env.GITHUB_REPO}`
+    (channel) => channel.name === `pr-${pull.number}-${pull.base.repo.name}`
   );
 
   if (!pullChannel) {

--- a/github.ts
+++ b/github.ts
@@ -1,10 +1,11 @@
 import { App as GithubApp } from "octokit";
 import { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
 import { SayFn, SlashCommand } from "@slack/bolt";
+import { PullRequest } from "@octokit/webhooks-types";
 
 export const addInitialComment = async (
   githubApp: GithubApp,
-  issue_number: number,
+  pull: PullRequest,
   channel: Channel
 ) => {
   const octokit = await githubApp.getInstallationOctokit(
@@ -20,8 +21,8 @@ The channel name is \`${channel.name}\`. All the reviewers have been invited to 
   try {
     await octokit.rest.issues.createComment({
       owner: process.env.GITHUB_OWNER,
-      repo: process.env.GITHUB_REPO,
-      issue_number,
+      repo: pull.base.repo.name,
+      issue_number: pull.number,
       body: commentBody,
     });
 
@@ -41,12 +42,15 @@ export const addComment = async (
     parseInt(process.env.GITHUB_INSTALLATION_ID)
   );
 
-  const pull_number = parseInt(command.channel_name.split('-')[1])
+  const splitName = command.channel_name.split('-');
+  const repoName = splitName.slice(2).join('-')
+
+  const pull_number = parseInt(splitName[1])
 
   try {
     await octokit.rest.issues.createComment({
       owner: process.env.GITHUB_OWNER,
-      repo: process.env.GITHUB_REPO,
+      repo: repoName,
       issue_number: pull_number,
       body: command.text,
     });

--- a/slack.ts
+++ b/slack.ts
@@ -49,7 +49,7 @@ export const createPullChannel = async (
 ): Promise<Channel> => {
   try {
     const newChannel = await slackApp.client.conversations.create({
-      name: `pr-${pull.number}-${process.env.GITHUB_REPO}`,
+      name: `pr-${pull.number}-${pull.base.repo.name}`,
     });
 
     const text = slackTextFromPullRequest(pull);


### PR DESCRIPTION
This removes any usages of the `GITHUB_REPO` env var, and insteads derives the values from the objects it has. In one instance I had to change an interface, but everywhere else it was pretty easy.

I did have to parse it from the Slack channel name, but we were already doing that so should be all good!