### PR TITLE
Only create Slack channel on demand

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -128,7 +128,8 @@ const onSubmitPullRequestReview = async (payload: PullRequestReviewSubmittedEven
   if (review.state === 'approved') {
     const channels = await getSlackChannels(slackApp)
 
-    const pullChannel = channels.find(channel => channel.name === `pr-${pull.number}-${pull.base.repo.name}`)
+    const channelName = channelNameFromPull(pull)
+    const pullChannel = channels.find(channel => channel.name === channelName)
 
     if (pullChannel?.id) {
       try {

--- a/github.ts
+++ b/github.ts
@@ -15,6 +15,7 @@ export const addOrUpdateManagedComment = async (githubApp: GithubApp, pull: Pull
   const existingManagedComment = existingComments.find(comment => comment.body?.includes(GITHUB_COMMENT_MARKER))
 
   const commentBody = `
+<!-- Do NOT delete this comments. They are used by Live Github to track this Pull Request -->
 <!-- ${GITHUB_COMMENT_MARKER} -->
 LiveGithub is listening to this PR :ear:
 

--- a/github.ts
+++ b/github.ts
@@ -15,7 +15,7 @@ export const addOrUpdateManagedComment = async (githubApp: GithubApp, pull: Pull
   const existingManagedComment = existingComments.find(comment => comment.body?.includes(GITHUB_COMMENT_MARKER))
 
   const commentBody = `
-<!-- Do NOT delete this comments. They are used by Live Github to track this Pull Request -->
+<!-- Do NOT delete these comments. They are used by Live Github to track this Pull Request -->
 <!-- ${GITHUB_COMMENT_MARKER} -->
 LiveGithub is listening to this PR :ear:
 

--- a/github.ts
+++ b/github.ts
@@ -1,30 +1,53 @@
 import { App as GithubApp } from 'octokit'
 import { Channel } from '@slack/web-api/dist/response/ConversationsListResponse'
 import { SayFn, SlashCommand } from '@slack/bolt'
-import { PullRequest, PullRequestReviewComment } from '@octokit/webhooks-types'
+import { PullRequest, PullRequestReviewComment, IssueComment } from '@octokit/webhooks-types'
+import { channelNameFromPull, pathToAppUrl } from './util'
 
-export const addInitialComment = async (githubApp: GithubApp, pull: PullRequest, channel: Channel): Promise<void> => {
+const GITHUB_COMMENT_MARKER = 'live-github-managed-comment'
+
+export const addOrUpdateManagedComment = async (githubApp: GithubApp, pull: PullRequest): Promise<void> => {
   const octokit = await githubApp.getInstallationOctokit(parseInt(process.env.GITHUB_INSTALLATION_ID!))
+  const channelName = channelNameFromPull(pull)
+  const openSlackUrl = pathToAppUrl(`/app/openSlackChannel/${pull.base.repo.name}/${pull.number}`)
 
-  const commentBody = `A Slack Channel was created for discussion of this PR :tada:
+  const existingComments = await getPullComments(githubApp, pull)
+  const existingManagedComment = existingComments.find(comment => comment.body?.includes(GITHUB_COMMENT_MARKER))
 
-The channel name is \`${channel.name}\`. All the reviewers have been invited to the channel, and it will be archived when the PR closes.
+  const commentBody = `
+<!-- ${GITHUB_COMMENT_MARKER} -->
+LiveGithub is listening to this PR :ear:
 
-[Click Here to open the channel](https://slack.com/app_redirect?channel=${channel.id})`
+LiveGithub can create a Slack Channel specifcally for this PR. When it's created all the reviewers will be invited to the channel, and it will be archived when the PR closes.
 
-  try {
-    await octokit.rest.issues.createComment({
+The channel name will be \`${channelName}\`.
+
+[Click Here to Create and Open the channel](${openSlackUrl})
+`.trim()
+
+  if (existingManagedComment) {
+    await octokit.rest.issues.updateComment({
       owner: process.env.GITHUB_OWNER!,
       repo: pull.base.repo.name,
       issue_number: pull.number,
       body: commentBody,
+      comment_id: existingManagedComment.id,
     })
+  } else {
+    try {
+      await octokit.rest.issues.createComment({
+        owner: process.env.GITHUB_OWNER!,
+        repo: pull.base.repo.name,
+        issue_number: pull.number,
+        body: commentBody,
+      })
 
-    console.log(`✅ Channel ${channel.name}: Successfully added initial comment`)
-  } catch (error) {
-    console.log(`❌ Channel ${channel.name}: Failed to add initial comment`)
-    console.log(error)
-    throw error
+      console.log(`✅ Channel ${channelName}: Successfully added initial comment`)
+    } catch (error) {
+      console.log(`❌ Channel ${channelName}: Failed to add initial comment`)
+      console.log(error)
+      throw error
+    }
   }
 }
 
@@ -75,10 +98,7 @@ export const getApproveReview = async (githubApp: GithubApp, pull: PullRequest) 
   }
 }
 
-export const getReviewComments = async (
-  githubApp: GithubApp,
-  pull: Pick<PullRequest, 'number' | 'base'>,
-): Promise<PullRequestReviewComment[]> => {
+export const getReviewComments = async (githubApp: GithubApp, pull: Pick<PullRequest, 'number' | 'base'>) => {
   try {
     const octokit = await githubApp.getInstallationOctokit(parseInt(process.env.GITHUB_INSTALLATION_ID!))
 
@@ -89,12 +109,36 @@ export const getReviewComments = async (
     })
 
     console.log(`✅ PR#${pull.number}: Successfully fetched review comments`)
-    return reviewComments.data as PullRequestReviewComment[]
+    return reviewComments.data
   } catch (error) {
     console.log(`❌ PR#${pull.number}: Failed to fetch review comments`)
     console.log(error)
     throw error
   }
+}
+
+export const getPullComments = async (githubApp: GithubApp, pull: Pick<PullRequest, 'number' | 'base'>) => {
+  const octokit = await githubApp.getInstallationOctokit(parseInt(process.env.GITHUB_INSTALLATION_ID!))
+
+  const response = await octokit.rest.issues.listComments({
+    owner: process.env.GITHUB_OWNER!,
+    repo: pull.base.repo.name,
+    issue_number: pull.number,
+  })
+
+  return response.data
+}
+
+export const getPullRequest = async (githubApp: GithubApp, repoName: string, pullNumber: number) => {
+  const octokit = await githubApp.getInstallationOctokit(parseInt(process.env.GITHUB_INSTALLATION_ID!))
+
+  const response = await octokit.rest.pulls.get({
+    owner: process.env.GITHUB_OWNER!,
+    repo: repoName,
+    pull_number: pullNumber,
+  })
+
+  return response.data
 }
 
 export const postReviewComentReply = async (

--- a/github.ts
+++ b/github.ts
@@ -9,7 +9,7 @@ const GITHUB_COMMENT_MARKER = 'live-github-managed-comment'
 export const addOrUpdateManagedComment = async (githubApp: GithubApp, pull: PullRequest): Promise<void> => {
   const octokit = await githubApp.getInstallationOctokit(parseInt(process.env.GITHUB_INSTALLATION_ID!))
   const channelName = channelNameFromPull(pull)
-  const openSlackUrl = pathToAppUrl(`/app/openSlackChannel/${pull.base.repo.name}/${pull.number}`)
+  const openSlackUrl = pathToAppUrl(`/app/openSlackChannel/v1/${pull.base.repo.name}/${pull.number}`)
 
   const existingComments = await getPullComments(githubApp, pull)
   const existingManagedComment = existingComments.find(comment => comment.body?.includes(GITHUB_COMMENT_MARKER))

--- a/github.ts
+++ b/github.ts
@@ -26,13 +26,14 @@ The channel name will be \`${channelName}\`.
 `.trim()
 
   if (existingManagedComment) {
-    await octokit.rest.issues.updateComment({
-      owner: process.env.GITHUB_OWNER!,
-      repo: pull.base.repo.name,
-      issue_number: pull.number,
-      body: commentBody,
-      comment_id: existingManagedComment.id,
-    })
+    if (existingManagedComment.body !== commentBody)
+      await octokit.rest.issues.updateComment({
+        owner: process.env.GITHUB_OWNER!,
+        repo: pull.base.repo.name,
+        issue_number: pull.number,
+        body: commentBody,
+        comment_id: existingManagedComment.id,
+      })
   } else {
     try {
       await octokit.rest.issues.createComment({

--- a/slack.ts
+++ b/slack.ts
@@ -3,6 +3,7 @@ import { App as SlackApp } from '@slack/bolt'
 import { Channel } from '@slack/web-api/dist/response/ConversationsListResponse'
 import dotenv from 'dotenv'
 import { Message } from '@slack/web-api/dist/response/ConversationsHistoryResponse'
+import { channelNameFromParts } from './util'
 
 dotenv.config({ path: './.env.local' })
 
@@ -76,7 +77,7 @@ export const createPullChannel = async (
 ): Promise<Channel> => {
   try {
     const newChannel = await slackApp.client.conversations.create({
-      name: `pr-${pull.number}-${repoName}`,
+      name: channelNameFromParts(repoName, pull.number),
     })
     const newChannelId = newChannel.channel!.id!
 

--- a/slack.ts
+++ b/slack.ts
@@ -1,7 +1,10 @@
 import { PullRequest, User } from '@octokit/webhooks-types'
 import { App as SlackApp } from '@slack/bolt'
 import { Channel } from '@slack/web-api/dist/response/ConversationsListResponse'
+import dotenv from 'dotenv'
 import { Message } from '@slack/web-api/dist/response/ConversationsHistoryResponse'
+
+dotenv.config({ path: './.env.local' })
 
 export const gitUserToSlackId = JSON.parse(process.env.GIT_USER_TO_SLACK_ID!)
 
@@ -52,7 +55,9 @@ export const getChannelHistory = async (slackApp: SlackApp, channel: Channel): P
   return await paginate(slackApp, botCommentResponse, x => x.messages)
 }
 
-export const slackTextFromPullRequest = (pull: PullRequest): string => {
+type CreatePullChannelPullRequest = Pick<PullRequest, 'html_url' | 'number' | 'title' | 'body'>
+
+export const slackTextFromPullRequest = (pull: CreatePullChannelPullRequest): string => {
   return `
 PR Opened! <${pull.html_url}|#${pull.number}>
 
@@ -64,10 +69,14 @@ ${pull.body}
 `
 }
 
-export const createPullChannel = async (slackApp: SlackApp, pull: PullRequest): Promise<Channel> => {
+export const createPullChannel = async (
+  slackApp: SlackApp,
+  repoName: string,
+  pull: CreatePullChannelPullRequest,
+): Promise<Channel> => {
   try {
     const newChannel = await slackApp.client.conversations.create({
-      name: `pr-${pull.number}-${pull.base.repo.name}`,
+      name: `pr-${pull.number}-${repoName}`,
     })
     const newChannelId = newChannel.channel!.id!
 

--- a/util.ts
+++ b/util.ts
@@ -1,0 +1,13 @@
+import { PullRequest } from '@octokit/webhooks-types'
+
+export const channelNameFromParts = (repoName: string, pullNumber: number | string): string =>
+  `pr-${pullNumber}-${repoName}`
+
+export const channelNameFromPull = (pull: Pick<PullRequest, 'number' | 'base'>): string =>
+  channelNameFromParts(pull.base.repo.name, pull.number)
+
+export const pathToAppUrl = (path: string): string => {
+  const modifiedPath = path.startsWith('/') ? path : `/${path}`
+
+  return `${process.env.BASE_URL}${modifiedPath}`
+}


### PR DESCRIPTION
We no longer create the Slack Channel on each PR, we only create it when
you either click the link in the 'managed comment' or if you say the
magic take it to slack command.

We also introduce the concept of a single 'managed comment' so that we
can have the potential to update this comment, if things change.
Before we only made this comment when we were creating the Slack
channel, but now we want this comment to exist first.
Before we were 'cheating' and using the Slack Channel existing as the
state in determining whether or not to leave this comment.
Now we are using the comment itself for this state, which is good for
being stateless! We add a special HTML comment to the top with a key we
can search for to find this comment later