### PR TITLE
Add extra new lines before PR footer

### DIFF
--- a/github.ts
+++ b/github.ts
@@ -51,7 +51,7 @@ The channel name will be \`${channelName}\`.
         owner: process.env.GITHUB_OWNER!,
         repo: pull.base.repo.name,
         pull_number: pull.number,
-        body: pull.body + commentBody,
+        body: pull.body + '\n\n' + commentBody,
       })
 
       console.log(`✅ PR#${pull.number}: Successfully added initial comment`)


### PR DESCRIPTION
When Live Github adds the 'footer' to each PR it didn't add any new
lines between the 'real' content and our future comments. This was a
common annoyance for me when I went to edit my Github PR descriptions,
so decided to fix it today!

This simply adds two new lines between the original body and our footer
when we insert it<!-- Do NOT delete these comments. They are used by Live Github to track this Pull Request -->
<!-- live-github-managed-comment -->

-----

LiveGithub is listening to this PR :ear:

LiveGithub can create a Slack Channel specifcally for this PR. When it's created all the reviewers will be invited to the channel, and it will be archived when the PR closes.

The channel name will be `pr-46-live-github`.

[Click Here to Create and Open the channel](https://live-github.herokuapp.com/app/openSlackChannel/v1/live-github/46)